### PR TITLE
update junit test to 4.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'com.google.zxing:javase:3.4.0'
     testCompileOnly 'org.projectlombok:lombok:1.18.12'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 test  {


### PR DESCRIPTION
update junit test to 4.13.2 because CVE-2020-15250 vulnerability on 4.12
